### PR TITLE
Update Travis CI and Codecov to move it closer to the default one for GAP packages

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: no
+    patch: yes
+    changes: no
+
+comment:
+  layout: "header, diff, changes, tree"
+  behavior: default
+
+ignore:
+  - "PackageInfo.g"
+  - "init.g"
+  - "read.g"
+  - "tst/*"     # ignore test harness code
+  - "tst/**/*"  # ignore test harness code

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,17 @@ addons:
 matrix:
   include:
     - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.11
+    - env: GAPBRANCH=stable-4.10
+    - env: GAPBRANCH=stable-4.9
+    - env: GAPBRANCH=master ABI=32
+      addons:
+        apt_packages:
+          - libgmp-dev:i386
+          - libreadline-dev:i386
+          - zlib1g-dev:i386
+          - gcc-multilib
+          - g++-multilib
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Computing decompositions of representations
+[![Build Status](https://travis-ci.org/gap-packages/RepnDecomp.svg?branch=master)](https://travis-ci.org/gap-packages/RepnDecomp)
+[![Code Coverage](https://codecov.io/github/gap-packages/RepnDecomp/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-packages/RepnDecomp)
 
-![CI build](https://api.travis-ci.com/gap-packages/RepnDecomp.svg?branch=master)
+# Computing decompositions of representations
 
 ## Overview
 


### PR DESCRIPTION
This PR:
- adds standard .codecov.yml
- updates .travis.yml to test the package under more branches from the GAP repository
- adds Travis CI and Codecov badges to the README

The only distinction of .travis.yml here from e.g. the one in https://github.com/gap-packages/example is that RepnDecomp also calls `./makedoc.sh` to extract manual examples into a test files (while some other packages extract examples too, but keep them under version control).