### PR TITLE
Accommodate correctly pluralized ViewStrings in GAP

### DIFF
--- a/examples/serre.g
+++ b/examples/serre.g
@@ -15,9 +15,8 @@ H := SymmetricGroup(3);;
 tau := FuncToHom@RepnDecomp(H, h -> PermutationMat(h, 3));;
 # Two canonical summands corresponding to the degree 2 and
 # trivial irreps (in that order)
-canonical_summands_H := CanonicalDecomposition(tau);
-#! [ <vector space over Cyclotomics, with 2 generators>,
-#!   <vector space over Cyclotomics, with 1 generators> ]
+List(CanonicalDecomposition(tau), Dimension);
+#! [ 2, 1 ]
 #! @EndExample
 #! @EndChunk
 


### PR DESCRIPTION
In a future version of GAP, some nouns will be correctly pluralised to match their number.  For example, the `ViewString` for `CyclicGroup(3);` will change from `<pc group of size 3 with 1 generators>` to `<pc group of size 3 with 1 generator>`.

This PR implements the solution discussed in #9 to make sure that this package remains backwards and forwards compatible with GAP, with respect to this change. See gap-system/gap#3992 and gap-system/gap#4050 for more context.

Closes #9.