### PR TITLE
PackageInfo.g: update Status

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -58,7 +58,7 @@ ArchiveFormats  := ".tar.gz .tar.bz2",
 ##    "dev"           for development versions of packages
 ##    "other"         for all other packages
 ##
-Status := "dev",
+Status := "deposited",
 
 AbstractHTML := "The <span class='pkgname'>RepnDecomp</span> package provides functions implementing various algorithms for decomposing linear representations of finite groups.",
 


### PR DESCRIPTION
This package is at the very least "deposited". I don't know if you also submitted it for refereeing by the GAP Council; if so, and if it was "accepted" then of course that should be also reflected in the status.