### PR TITLE
Avoid syntax warnings when IO is not loaded

### DIFF
--- a/lib/serre.gi
+++ b/lib/serre.gi
@@ -354,8 +354,8 @@ IrreducibleDecompositionCollectedHybrid@ := function(rho)
     parallel := ValueOption("parallel");
     if IsBoundGlobal("ParListByFork") then
       ParListByFork := ValueGlobal("ParListByFork");
-    else
-      parallel := fail;
+    elif parallel <> fail then
+        Error("The GAP package IO must be loaded to use the parallel option!");
     fi;
     if IsInt(parallel) then
         irred_decomp := ParListByFork(irreps, do_decompose, rec(NumberJobs := parallel));
@@ -402,7 +402,7 @@ InstallMethod( REPN_ComputeUsingSerre, "for linear reps", [ IsGroupHomomorphism 
     if IsBoundGlobal("ParListByFork") then
         ParListByFork := ValueGlobal("ParListByFork");
     elif parallel <> fail then
-        Error("I need the package IO >= 4.7.0 to use the parallel option!");
+        Error("The GAP package IO must be loaded to use the parallel option!");
     fi;
     if parallel <> fail then
         # if the parallel option is set

--- a/lib/serre.gi
+++ b/lib/serre.gi
@@ -353,10 +353,11 @@ IrreducibleDecompositionCollectedHybrid@ := function(rho)
                                                                                         irrep));
     parallel := ValueOption("parallel");
     if IsBoundGlobal("ParListByFork") then
-      ParListByFork := ValueGlobal("ParListByFork");
+        ParListByFork := ValueGlobal("ParListByFork");
     elif parallel <> fail then
         Error("The GAP package IO must be loaded to use the parallel option!");
     fi;
+ 
     if IsInt(parallel) then
         irred_decomp := ParListByFork(irreps, do_decompose, rec(NumberJobs := parallel));
     elif parallel <> fail then
@@ -404,19 +405,13 @@ InstallMethod( REPN_ComputeUsingSerre, "for linear reps", [ IsGroupHomomorphism 
     elif parallel <> fail then
         Error("The GAP package IO must be loaded to use the parallel option!");
     fi;
-    if parallel <> fail then
-        # if the parallel option is set
-        if IsPackageMarkedForLoading("IO", ">= 4.7.0") then
-            if IsInt(parallel) then
-                irred_decomp := ParListByFork(irreps, do_decompose, rec(NumberJobs := parallel));
-            else
-                # we default the number of jobs to 4 since everyone
-                # has 4 threads, at least
-                irred_decomp := ParListByFork(irreps, do_decompose, rec(NumberJobs := 4));
-            fi;
-        else
-            Error("I need the package IO >= 4.7.0 to use the parallel option!");
-        fi;
+
+    if IsInt(parallel) then
+        irred_decomp := ParListByFork(irreps, do_decompose, rec(NumberJobs := parallel));
+    elif parallel <> fail then
+        # we default the number of jobs to 4 since everyone
+        # has 4 threads, at least
+        irred_decomp := ParListByFork(irreps, do_decompose, rec(NumberJobs := 4));
     else
         irred_decomp := List(irreps, do_decompose);
     fi;

--- a/lib/serre.gi
+++ b/lib/serre.gi
@@ -339,7 +339,7 @@ end;
 # method to get irreducibles from that. Uses orthonormal basis for
 # C_rho if given.
 IrreducibleDecompositionCollectedHybrid@ := function(rho)
-    local irreps, G, irred_decomp, do_decompose, parallel;
+    local irreps, G, irred_decomp, do_decompose, parallel, ParListByFork;
     G := Source(rho);
     irreps := ValueOption("irreps");
     if irreps = fail then
@@ -352,6 +352,11 @@ IrreducibleDecompositionCollectedHybrid@ := function(rho)
                                                                  IrrepCanonicalSummand@(rho,
                                                                                         irrep));
     parallel := ValueOption("parallel");
+    if IsBoundGlobal("ParListByFork") then
+      ParListByFork := ValueGlobal("ParListByFork");
+    else
+      parallel := fail;
+    fi;
     if IsInt(parallel) then
         irred_decomp := ParListByFork(irreps, do_decompose, rec(NumberJobs := parallel));
     elif parallel <> fail then
@@ -364,7 +369,7 @@ IrreducibleDecompositionCollectedHybrid@ := function(rho)
 end;
 
 InstallMethod( REPN_ComputeUsingSerre, "for linear reps", [ IsGroupHomomorphism ], function(rho)
-    local irreps, irr_chars, centralizer_basis, irred_decomp, new_bases, basis, basis_change, diag_rho, char_rho_basis, all_sizes, sizes, centralizer_blocks, G, parallel, do_decompose;
+    local irreps, irr_chars, centralizer_basis, irred_decomp, new_bases, basis, basis_change, diag_rho, char_rho_basis, all_sizes, sizes, centralizer_blocks, G, parallel, do_decompose, ParListByFork;
 
     G := Source(rho);
 
@@ -394,7 +399,11 @@ InstallMethod( REPN_ComputeUsingSerre, "for linear reps", [ IsGroupHomomorphism 
     end;
 
     parallel := ValueOption("parallel");
-
+    if IsBoundGlobal("ParListByFork") then
+        ParListByFork := ValueGlobal("ParListByFork");
+    elif parallel <> fail then
+        Error("I need the package IO >= 4.7.0 to use the parallel option!");
+    fi;
     if parallel <> fail then
         # if the parallel option is set
         if IsPackageMarkedForLoading("IO", ">= 4.7.0") then


### PR DESCRIPTION
This is a hack to resolve #23; perhaps @fingolfin or someone else has a nicer solution?